### PR TITLE
Upgrade requeriments for lilac.master

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,7 +13,7 @@ django-cors-headers
 mysqlclient
 PyJWT
 gunicorn     # MIT
-path.py==3.0.1
+path.py==9.1
 python-dateutil==2.4.0
 newrelic==4.8.0.110            # New Relic
 edx-django-release-util

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -101,11 +101,11 @@ newrelic==4.8.0.110
     #   edx-django-utils
 openapi-codec==1.3.2
     # via django-rest-swagger
-path.py==3.0.1
+path.py==9.1
     # via -r requirements/base.in
-pbr==5.5.1
+pbr==5.8.0
     # via stevedore
-psutil==5.8.0
+psutil==5.9.0
     # via edx-django-utils
 pycparser==2.20
     # via cffi
@@ -155,7 +155,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via coreapi
 urllib3==1.25.11
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -181,7 +181,7 @@ packaging==20.9
     # via
     #   pytest
     #   tox
-path.py==3.0.1
+path.py==9.1
     # via -r requirements/base.txt
 pbr==5.5.1
     # via


### PR DESCRIPTION
### Description

As operator we want to upgrade the requeriments in order to be able to run lilac.master without have to create a custom branch to update requeriments. Port of PR #286

### Supporting information

The version of path is 10 years old and supports only python 2

### Deadline

None