### PR TITLE
docs: add comment about auth refactor

### DIFF
--- a/notesapi/v1/permissions.py
+++ b/notesapi/v1/permissions.py
@@ -38,6 +38,10 @@ class HasAccessToken(BasePermission):
             logger.debug("No token found in headers")
             return False
         try:
+            # TODO: Determine how and if we could remove `jwt.decode` from being called directly from this
+            #   service. Instead, use `jwt_decode_handler` or other library code that is used in other services.
+            #   It would be useful to simplify authentication within the platform, especially during upgrades of
+            #   authentication related dependencies.
             data = jwt.decode(
                 token,
                 settings.CLIENT_SECRET,


### PR DESCRIPTION
When upgrading jwt libraries in the past, this service needed more attention than some others because it was using calls that are encapsulated in other services by methods that exist in our shared library. It would be useful to clean this up some day, but this comment at least leaves a note in context.