### PR TITLE
fix: Remove MAINTAINER label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM ubuntu:focal as app
-MAINTAINER sre@edx.org
-
 
 # Packages installed:
 # git; Used to pull in particular requirements from github rather than pypi, 


### PR DESCRIPTION
This is DEPRd and the Aurora team now owns this dockerfile