### PR TITLE
docs: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for edx-notes-api
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, they will
+# be requested for review when someone opens a pull request.
+*       @openedx/content-aurora


### PR DESCRIPTION
Add a CODEOWNERS file to auto-request review from the owning team.