### PR TITLE
fix: remove new relic pin to unblock django upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -97,7 +97,6 @@ mysqlclient==2.2.0
     # via -r requirements/base.in
 newrelic==4.8.0.110
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-django-utils
 packaging==23.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -95,7 +95,7 @@ inflection==0.5.1
     # via drf-yasg
 mysqlclient==2.2.0
     # via -r requirements/base.in
-newrelic==4.8.0.110
+newrelic==9.1.2
     # via
     #   -r requirements/base.in
     #   edx-django-utils

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,7 +18,6 @@ elasticsearch-dsl>=7.2,<8.0
 django-elasticsearch-dsl>=7.1,<8.0
 path.py==9.1
 python-dateutil==2.4.0
-newrelic==4.8.0.110
 more-itertools==5.0.0
 pylint==1.5.0
 django-cors-headers==3.14.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -164,7 +164,6 @@ mysqlclient==2.2.0
     # via -r requirements/base.txt
 newrelic==4.8.0.110
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-django-utils
 packaging==23.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -162,7 +162,7 @@ more-itertools==5.0.0
     #   -r requirements/test.in
 mysqlclient==2.2.0
     # via -r requirements/base.txt
-newrelic==4.8.0.110
+newrelic==9.1.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils


### PR DESCRIPTION
Unpins newrelic to bring in a bug fix that is causing 404s to be converted to 500, which is blocking the Django 4.2 upgrade.