### PR TITLE
fix: set JSONRenderer as the DEFAULT_RENDERER_CLASSES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,42 +1,38 @@
-Part of `edX code`__.
-
-__ http://code.edx.org/
-
 edX Student Notes API |build-status|
-====================================
+####################################
 
 This is a backend store for edX Student Notes.
 
 Overview
---------
+********
 
 The edX Notes API is designed to be compatible with the `Annotator <http://annotatorjs.org/>`__.
 
 Getting Started
----------------
+***************
 
 1. Install `ElasticSearch 7.8.0 <https://www.elastic.co/blog/elasticsearch-7-8-0-released>`__.
 
 2. Install the requirements:
 
-   ::
+   .. code-block:: bash
 
-       $ make develop
+      make develop
 
 3. Create index and put mapping:
 
-   ::
+   .. code-block:: bash
 
-       $ make create-index
+      make create-index
 
 4. Run the server:
 
-   ::
+   .. code-block:: bash
 
-       $ make run
+      make run
 
-Configuration:
---------------
+Configuration
+*************
 
 ``CLIENT_ID`` - OAuth2 Client ID, which is to be found in ``aud`` field of IDTokens which authorize users
 
@@ -49,20 +45,21 @@ Configuration:
 ``ELASTICSEARCH_DSL['default']['hosts']`` - Your ElasticSearch host
 
 Running Tests
--------------
+*************
 
 Run ``make validate`` install the requirements, run the tests, and run
 lint.
 
 How To Resync The Index
------------------------
+***********************
+
 edX Notes Store uses `Django elasticsearch DSL <https://django-elasticsearch-dsl.readthedocs.io/>`_ which comes with several management commands.
 
 Please read more about ``search_index`` management commands
 `here <https://django-elasticsearch-dsl.readthedocs.io/en/latest/management.html>`_.
 
 License
--------
+*******
 
 The code in this repository is licensed under version 3 of the AGPL unless
 otherwise noted.
@@ -70,19 +67,19 @@ otherwise noted.
 Please see ``LICENSE.txt`` for details.
 
 How To Contribute
------------------
+*****************
 
 Contributions are very welcome.
 
 Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 
 Reporting Security Issues
--------------------------
+*************************
 
 Please do not report security issues in public. Please email security@openedx.org
 
 Mailing List and IRC Channel
-----------------------------
+****************************
 
 You can discuss this code on the `edx-code Google Group`__ or in the
 ``edx-code`` IRC channel on Freenode.

--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -83,6 +83,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.SessionAuthentication'],
     'DEFAULT_PERMISSION_CLASSES': ['notesapi.v1.permissions.HasAccessToken'],
     'DEFAULT_PAGINATION_CLASS': 'notesapi.v1.paginators.NotesPaginator',
+    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
 }
 
 # CORS is configured to allow all origins because requests to the


### PR DESCRIPTION
This will introduce a similar approach as `edx-platform` to set `JSONRenderer` as the `DEFAULT_RENDERER_CLASSES`. with this, we don't have Browsable APIs anymore. also, some code reformatting with black and RST cleanup in README. 

See here for more context: https://github.com/overhangio/tutor-notes/pull/35