### PR TITLE
fix: path import is fixed

### DIFF
--- a/notesserver/settings/yaml_config.py
+++ b/notesserver/settings/yaml_config.py
@@ -2,7 +2,7 @@ from os import environ
 
 import yaml
 from django.core.exceptions import ImproperlyConfigured
-from path import path
+from path import Path
 
 from notesserver.settings.logger import build_logging_config
 
@@ -21,7 +21,7 @@ EDXNOTES_CONFIG_ROOT = os.environ.get('EDXNOTES_CONFIG_ROOT')
 if not EDXNOTES_CONFIG_ROOT:
     raise ImproperlyConfigured("EDXNOTES_CONFIG_ROOT must be defined in the environment.")
 
-CONFIG_ROOT = path(EDXNOTES_CONFIG_ROOT)
+CONFIG_ROOT = Path(EDXNOTES_CONFIG_ROOT)
 
 with open(CONFIG_ROOT / "edx_notes_api.yml") as yaml_file:
     config_from_yaml = yaml.safe_load(yaml_file)


### PR DESCRIPTION
### Description
After upgrading path-py from 9.1 to 12.5.0 [here](https://github.com/openedx/edx-notes-api/pull/436/files#diff-0940fec0afe21798f617cc4522db676f15769ae28a72992b8d19216ef7b1c3b5) they upgrade the import as well from p to capital P as `import path from Path`

Its only being used in `yaml_config.py` file