### PR TITLE
refactor: update deprecated requestmetric middleware

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -46,7 +46,7 @@ MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 )
 


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/815
- The middleware was [deprecated/renamed](https://github.com/openedx/edx-drf-extensions/blob/2b4347518680046aa54caa404c030d0ffe308acf/CHANGELOG.rst#620---2020-08-24) in the `edx-drf-extensions==6.2.0` but was pending to be updated.