### PR TITLE
fix: Use edx-django-utils API instead of calling newrelic directly

### DIFF
--- a/notesapi/v1/views/common.py
+++ b/notesapi/v1/views/common.py
@@ -1,20 +1,17 @@
 #  pylint:disable=possibly-used-before-assignment
 import json
 import logging
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from edx_django_utils.monitoring import set_custom_attribute
 from rest_framework import status
 from rest_framework.generics import GenericAPIView, ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-try:
-    import newrelic.agent
-except ImportError:  # pragma: no cover
-    newrelic = None  # pylint: disable=invalid-name
 
 from notesapi.v1.models import Note
 from notesapi.v1.serializers import NoteSerializer
@@ -402,9 +399,7 @@ class AnnotationListView(GenericAPIView):
             note = Note.create(self.request.data)
             note.full_clean()
 
-            # Gather metrics for New Relic so we can slice data in New Relic Insights
-            if newrelic:  # pragma: no cover
-                newrelic.agent.add_custom_parameter("notes.count", total_notes)
+            set_custom_attribute("notes.count", total_notes)
         except ValidationError as error:
             log.debug(error, exc_info=True)
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/notesserver/views.py
+++ b/notesserver/views.py
@@ -4,15 +4,11 @@ import traceback
 from django.db import connection
 from django.http import JsonResponse
 from django.http import HttpResponse
+from edx_django_utils.monitoring import ignore_transaction
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-
-try:
-    import newrelic.agent
-except ImportError:  # pragma: no cover
-    newrelic = None  # pylint: disable=invalid-name
 
 from notesapi.v1.views import get_annotation_search_view_class
 from notesapi.v1.views import SearchViewRuntimeError
@@ -45,8 +41,7 @@ def heartbeat(request):
     """
     ElasticSearch and database are reachable and ready to handle requests.
     """
-    if newrelic:  # pragma: no cover
-        newrelic.agent.ignore_transaction()
+    ignore_transaction()  # no need to record telemetry for heartbeats
     try:
         db_status()
     except Exception:  # pylint: disable=broad-exception-caught

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,6 @@ PyJWT
 gunicorn     # MIT
 path.py
 python-dateutil
-newrelic
 edx-django-release-util
 edx-django-utils
 edx-drf-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -109,9 +109,7 @@ meilisearch==0.34.0
 mysqlclient==2.2.7
     # via -r requirements/base.in
 newrelic==10.7.0
-    # via
-    #   -r requirements/base.in
-    #   edx-django-utils
+    # via edx-django-utils
 packaging==24.2
     # via
     #   django-nine


### PR DESCRIPTION
These changes will cause telemetry to start being reported when annotations are created. (No change for whether notesserver heartbeat calls emit telemetry, as that is currently only supported for New Relic anyhow.)

This also removes the newrelic dependency, though it is still pulled in by edx-django-utils indirectly, for now.

[EDIT: This originally just wrapped the newrelic import in a try block, but the new PR removes newrelic references entirely.]