### PR TITLE
[WIP] Text search fixed for elasticsearch for course_id field

### DIFF
--- a/notesapi/v1/views/elasticsearch.py
+++ b/notesapi/v1/views/elasticsearch.py
@@ -34,7 +34,7 @@ class AnnotationSearchView(BaseAnnotationSearchView):
 
     # https://django-elasticsearch-dsl-drf.readthedocs.io/en/latest/advanced_usage_examples.html
     filter_fields = {
-        "course_id": "course_id",
+        "course_id": "course_id.keyword",
         "user": "user",
         "usage_id": {
             "field": "usage_id",


### PR DESCRIPTION
### Relevant Ticket
https://github.com/mitodl/hq/issues/6505

### Description
Since `course_id` is a text field, filtering on `course_id` directly won’t work because Elasticsearch tokenizes it. 

### How can we test ?

1. Make sure your notes setup is working properly with edX and its using Elasticsearch
2. Add notes on any course
3. Search for that Note -- It should be searchable